### PR TITLE
Correct classic dialog nodes for imageimagetext component

### DIFF
--- a/src/main/content/jcr_root/apps/foundation/components/imageimagetext/dialog.xml
+++ b/src/main/content/jcr_root/apps/foundation/components/imageimagetext/dialog.xml
@@ -85,7 +85,7 @@
             sizeLimit="100"
             title="Image1"
             xtype="html5smartimage"/>
-        <tab2
+        <tab3
             jcr:primaryType="cq:Widget"
             title="Advanced Image1 Properties"
             xtype="panel">
@@ -125,8 +125,8 @@
                     value="foundation/components/image"
                     xtype="hidden"/>
             </items>
-        </tab2>
-        <tab3
+        </tab3>
+        <tab4
             jcr:primaryType="cq:Widget"
             cropParameter="./image2/imageCrop"
             ddGroups="[media]"
@@ -139,7 +139,7 @@
             sizeLimit="100"
             title="Image2"
             xtype="html5smartimage"/>
-        <tab4
+        <tab5
             jcr:primaryType="cq:Widget"
             title="Advanced Image2 Properties"
             xtype="panel">
@@ -179,8 +179,8 @@
                     value="foundation/components/image"
                     xtype="hidden"/>
             </items>
-        </tab4>
-        <tab5
+        </tab5>
+        <tab6
             jcr:primaryType="cq:Widget"
             xtype="componentstyles"/>
     </items>


### PR DESCRIPTION
Fix numbering on the tabs in the classic dialog xml for the imageimagetext component
